### PR TITLE
Add julia set rotation

### DIFF
--- a/src/components/info/ChangeCoordinatesCard.tsx
+++ b/src/components/info/ChangeCoordinatesCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Grid, Grow, TextField, InputBase } from '@material-ui/core';
+import { Button, Card, Grid, Grow, TextField } from '@material-ui/core';
 import React, { useState } from 'react';
 import { ChangeCoordinatesCardProps } from '../../common/info';
 import { startPos, startTheta, startZoom } from '../../common/values';

--- a/src/components/info/ChangeCoordinatesCard.tsx
+++ b/src/components/info/ChangeCoordinatesCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Grid, Grow, TextField } from '@material-ui/core';
+import { Button, Card, Grid, Grow, TextField, InputBase } from '@material-ui/core';
 import React, { useState } from 'react';
 import { ChangeCoordinatesCardProps } from '../../common/info';
 import { startPos, startTheta, startZoom } from '../../common/values';
@@ -30,14 +30,18 @@ const ChangeCoordinatesCard = (props: ChangeCoordinatesCardProps): JSX.Element =
             size="small"
             style={{ width: '12ch' }}
             onChange={(e) => setX(Number(e.target.value))}
-            value={x}
+            type="number"
+            defaultValue={x}
+            inputProps={{ step: 0.01 }}
             label="x"
           />
           <TextField
             size="small"
             style={{ width: '12ch' }}
             onChange={(e) => setY(Number(e.target.value))}
-            value={y}
+            type="number"
+            defaultValue={y}
+            inputProps={{ step: 0.01 }}
             label="y"
           />
           <Grid container direction="row" justify="space-around">
@@ -45,14 +49,17 @@ const ChangeCoordinatesCard = (props: ChangeCoordinatesCardProps): JSX.Element =
               size="small"
               style={{ width: '5ch' }}
               onChange={(e) => setZoom(Number(e.target.value))}
-              value={zoom}
+              type="number"
+              defaultValue={zoom}
+              inputProps={{ min: 0 }}
               label="zoom"
             />
             <TextField
               size="small"
               style={{ width: '3ch' }}
               onChange={(e) => setTheta(Number(e.target.value))}
-              value={theta}
+              type="number"
+              defaultValue={theta}
               label="theta"
             />
           </Grid>

--- a/src/components/info/ChangeCoordinatesCard.tsx
+++ b/src/components/info/ChangeCoordinatesCard.tsx
@@ -56,10 +56,11 @@ const ChangeCoordinatesCard = (props: ChangeCoordinatesCardProps): JSX.Element =
             />
             <TextField
               size="small"
-              style={{ width: '3ch' }}
+              style={{ width: '5ch' }}
               onChange={(e) => setTheta(Number(e.target.value))}
               type="number"
               defaultValue={theta}
+              inputProps={{ step: 0.1 }}
               label="theta"
             />
           </Grid>

--- a/src/components/render/JuliaRenderer.tsx
+++ b/src/components/render/JuliaRenderer.tsx
@@ -26,6 +26,7 @@ export default function JuliaRenderer(props: JuliaRendererProps): JSX.Element {
   const [{ xy }] = props.controls.xyCtrl;
   // const [{ theta, last_pointer_angle }, setControlRot] = props.controls.rot;
   const [{ z }, setControlZoom] = props.controls.zoomCtrl;
+  const [{ theta }] = props.controls.rotCtrl;
   const maxI = props.maxI; // -> global
   const AA = props.useAA ? 2 : 1;
 
@@ -45,6 +46,7 @@ export default function JuliaRenderer(props: JuliaRendererProps): JSX.Element {
     zoom: z,
     xy: xy,
     c: props.c,
+    theta: theta,
     maxI: maxI,
     // screenScaleMultiplier: screenScaleMultiplier,
   };

--- a/src/shaders/newSmoothJuliaShader.js
+++ b/src/shaders/newSmoothJuliaShader.js
@@ -64,7 +64,13 @@ void main() {
   
   // constant "c" to add, based on mandelbrot position
   vec2 c = u_c;
-  vec2 z = u_xy + p/u_zoom;
+
+  float sinT = sin(u_theta);
+  float cosT = cos(u_theta);
+
+  vec2 xy = vec2( p.x*cosT - p.y*sinT, p.x*sinT + p.y*cosT );
+  // c is based on offset and grid position, z_0 = 0
+  vec2 z = u_xy + xy/u_zoom;
 
   float l = julia(z, c);
   col += 0.5 + 0.5*cos( 3.0 + l*0.15 + vec3(0.0,0.6,1.0));


### PR DESCRIPTION
### What
This PR adds functionality to rotate the Julia set viewer.
### Why
This PR allows developers to set the rotation for the Julia set, which will then rotate the view. This doesn't include an UI for users to interface with this, so for now this functionality is just for developers. 
### How
The rotation is accomplished by using a method similar to the Mandelbrot shader, where trigonometric functions are used with the chosen rotation angle to compute the shift for each point.